### PR TITLE
deprecate: toItemStack method

### DIFF
--- a/src/main/java/me/henrique/itemapi/itembuilder/ItemBuilder.java
+++ b/src/main/java/me/henrique/itemapi/itembuilder/ItemBuilder.java
@@ -69,8 +69,14 @@ public class ItemBuilder {
         itemStack.setItemMeta(meta);
         return this;
     }
-
+    @Deprecated
     public ItemStack toItemStack(){
+        ItemMeta meta = itemStack.getItemMeta();
+        itemStack.setItemMeta(meta);
+        return itemStack;
+    }
+
+    public ItemStack build(){
         ItemMeta meta = itemStack.getItemMeta();
         itemStack.setItemMeta(meta);
         return itemStack;


### PR DESCRIPTION
since it is a builder class i assume that a build method is way more proper than toItemStack